### PR TITLE
Cloudbox: update-rclone tag

### DIFF
--- a/cloudbox.yml
+++ b/cloudbox.yml
@@ -15,7 +15,7 @@
     - { role: watchtower, tags: ['full', 'feeder', 'plex', 'update-watchtower'] }
     - { role: portainer, tags: ['full', 'feeder', 'update-portainer'] }
     - { role: plexdrive, tags: ['full', 'feeder', 'plex'] }
-    - { role: rclone, tags: ['full', 'feeder', 'plex'] }
+    - { role: rclone, tags: ['full', 'feeder', 'plex', 'update-rclone'] }
     - { role: organizr, tags: ['full', 'feeder', 'update-organizr'] }
     - { role: scripts, tags: ['full', 'feeder', 'plex'] }
     - { role: unionfs_cleaner, tags: ['full', 'feeder']}

--- a/roles/rclone/tasks/main.yml
+++ b/roles/rclone/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: "Get {{user}} uid"
+  shell: "id -u {{user}}"
+  register: uid
+
+- name: "Get {{user}} gid"
+  shell: "id -g {{user}}"
+  register: gid
+
 - name: "Unarchive rclone v{{rclone.version}}"
   unarchive:
     src: https://github.com/ncw/rclone/releases/download/v{{ rclone.version }}/rclone-v{{ rclone.version }}-linux-amd64.zip


### PR DESCRIPTION
Useful when wanting to update rclone to a newer version.  Tested OK. 