### PR TITLE
updated backup role so it starts all previously running containers

### DIFF
--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -217,7 +217,7 @@
   - name: "Check rclone cloudbox.tar datestamp"
     shell: "rclone lsl {{backup.rclone_dest}}/cloudbox.tar|cut -d ' ' -f 2,3|cut -d '.' -f 1|sed s/' '/_/g"
     environment:
-    tags: something
+    tags: timestamp
     register: rclone
     when: backup.use_rclone
 
@@ -227,7 +227,7 @@
     when: backup.use_rclone
 
   - name: "Upload backup with rclone to \"{{backup.rclone_dest}}\""
-    command: "rclone copy '{{backup.tar_dest}}/cloudbox.tar' '{{backup.rclone_dest}}/' --stats=30s -v --transfers=2 --drive-chunk-size=64M --log-file='{{playbook_dir}}/backup_rclone.log'"
+    command: "rclone copy '{{backup.tar_dest}}/cloudbox.tar' '{{backup.rclone_dest}}' --stats=30s -v --transfers=2 --drive-chunk-size=64M --log-file='{{playbook_dir}}/backup_rclone.log'"
     become: true
     become_user: "{{user}}"
     when: backup.use_rclone

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -215,14 +215,12 @@
     shell: "chown -R {{user}}:{{user}} {{backup.tar_dest}}"
 
   - name: "Check rclone cloudbox.tar datestamp"
-    shell: "rclone lsl {{backup.rclone_dest}}/cloudbox.tar|cut -d ' ' -f 2,3|cut -d '.' -f 1|sed s/' '/_/g"
-    environment:
-    tags: timestamp
-    register: rclone
+    shell: "rclone lsl {{backup.rclone_dest}}/cloudbox.tar|cut -d ' ' -f 2,3|cut -d '.' -f 1|sed s/' '/_/g|sed s/':'/./g"
+    register: rclone_timestamp
     when: backup.use_rclone
 
   - name: "Move off old cloudbox.tar on \"{{backup.rclone_dest}}\""
-    shell: "rclone moveto '{{backup.rclone_dest}}/cloudbox.tar' '{{backup.rclone_dest}}/cloudbox.{{rclone.stdout}}.tar' 2>/dev/null"
+    shell: "rclone moveto '{{backup.rclone_dest}}/cloudbox.tar' '{{backup.rclone_dest}}/cloudbox.{{rclone_timestamp.stdout}}.tar' 2>/dev/null"
     ignore_errors: yes
     when: backup.use_rclone
 

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -214,8 +214,20 @@
   - name: "Set {{backup.tar_dest}} owner"
     shell: "chown -R {{user}}:{{user}} {{backup.tar_dest}}"
 
+  - name: "Check rclone cloudbox.tar datestamp"
+    shell: "rclone lsl {{backup.rclone_dest}}/cloudbox.tar|cut -d ' ' -f 2,3|cut -d '.' -f 1|sed s/' '/_/g"
+    environment:
+    tags: something
+    register: rclone
+    when: backup.use_rclone
+
+  - name: "Move off old cloudbox.tar on \"{{backup.rclone_dest}}\""
+    shell: "rclone moveto '{{backup.rclone_dest}}/cloudbox.tar' '{{backup.rclone_dest}}/cloudbox.{{rclone.stdout}}.tar' 2>/dev/null"
+    ignore_errors: yes
+    when: backup.use_rclone
+
   - name: "Upload backup with rclone to \"{{backup.rclone_dest}}\""
-    command: "rclone copy '{{backup.tar_dest}}' '{{backup.rclone_dest}}' --stats=30s -v --transfers=2 --drive-chunk-size=64M --log-file='{{playbook_dir}}/backup_rclone.log'"
+    command: "rclone copy '{{backup.tar_dest}}/cloudbox.tar' '{{backup.rclone_dest}}/' --stats=30s -v --transfers=2 --drive-chunk-size=64M --log-file='{{playbook_dir}}/backup_rclone.log'"
     become: true
     become_user: "{{user}}"
     when: backup.use_rclone

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -87,6 +87,11 @@
       owner: "{{user}}"
       mode: 0775
 
+  - name: "Gathering list of running containers"
+    shell: "docker ps --format '{{ '{{' }} .Names{{ '}}' }}' | xargs echo -n"
+    register: docker_running_containers
+    ignore_errors: yes
+    
   - name: "Stop all containers"
     shell: "docker stop $(docker ps -aq)"
     ignore_errors: yes
@@ -182,7 +187,7 @@
       timeout: 5
 
   - name: "Start containers"
-    shell: 'docker start plexrequests plexpy plex radarr sonarr nzbhydra jackett rutorrent nzbget organizr portainer letsencrypt nginx-proxy'
+    shell: 'docker start {{docker_running_containers.stdout}}'
     ignore_errors: yes
 
   - name: "Pushover Message: Started Cloudbox containers."


### PR DESCRIPTION
It now records what containers were running before the backup so it can start them back up again. This covers users adding additional containers outside of CB.