### PR TITLE
Add hosts entry for Lazyman

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -40,6 +40,7 @@
     - nodejs-legacy
     - npm
     - glances
+    - dnsutils
 
 - name: Install common pip modules
   pip: "name={{item}} state=latest"

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -41,6 +41,10 @@
 - debug: msg="Using plex claim token {{plex_claim.user_input}}"
   when: plex_prefs.stat.exists == False
 
+- name: Grab IP for Lazyman
+  shell: "ping -c1 powersports.ml | sed -nE 's/^PING[^(]+\\(([^)]+)\\).*/\\1/p'"
+  register: lazyman_ip
+
 - name: Create and start container
   docker_container:
     name: plex
@@ -78,7 +82,7 @@
       - "/tmp:/tmp"
     devices: "{{ '/dev/dri:/dev/dri' if dev_dri.stat.exists == True | default(false) else omit }}"
     restart_policy: always
-    etc_hosts: {'metric.plex.tv': '127.0.0.1', 'metrics.plex.tv': '127.0.0.1', 'analytics.plex.tv': '127.0.0.1'}
+    etc_hosts: {'metric.plex.tv': '127.0.0.1', 'metrics.plex.tv': '127.0.0.1', 'analytics.plex.tv': '127.0.0.1', 'mf.svc.nhl.com': '{{ lazyman_ip.stdout }}', 'mlb-ws-mf.media.mlb.com': '{{ lazyman_ip.stdout }}'}
     networks:
       - name: cloudbox
         aliases:

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -42,7 +42,7 @@
   when: plex_prefs.stat.exists == False
 
 - name: Grab IP for Lazyman
-  shell: "ping -c1 powersports.ml | sed -nE 's/^PING[^(]+\\(([^)]+)\\).*/\\1/p'"
+  shell: "dig +short powersports.ml"
   register: lazyman_ip
 
 - name: Create and start container
@@ -82,7 +82,14 @@
       - "/tmp:/tmp"
     devices: "{{ '/dev/dri:/dev/dri' if dev_dri.stat.exists == True | default(false) else omit }}"
     restart_policy: always
-    etc_hosts: {'metric.plex.tv': '127.0.0.1', 'metrics.plex.tv': '127.0.0.1', 'analytics.plex.tv': '127.0.0.1', 'mf.svc.nhl.com': '{{ lazyman_ip.stdout }}', 'mlb-ws-mf.media.mlb.com': '{{ lazyman_ip.stdout }}'}
+    etc_hosts: >
+      {
+        "metric.plex.tv": "127.0.0.1",
+        "metrics.plex.tv": "127.0.0.1",
+        "analytics.plex.tv": "127.0.0.1",
+        "mf.svc.nhl.com": "{{ (lazyman_ip.stdout != "")|ternary(lazyman_ip.stdout, '127.0.0.1') }}",
+        "mlb-ws-mf.media.mlb.com": "{{ (lazyman_ip.stdout != "")|ternary(lazyman_ip.stdout, '127.0.0.1') }}"
+      }
     networks:
       - name: cloudbox
         aliases:


### PR DESCRIPTION
Not super important that it gets added to the main repo here, was just something I added to my fork and figured I'd create a pull request here to let you decide if you want to add it in. It just adds the necessary hosts entries to the plex container, in the event a user decides they want to install the Lazyman plex channel.

https://github.com/nomego/Lazyman.bundle#modify-hosts-file

**EDIT:** I realized I didn't follow the contribution guidelines exactly, but it's a very small change. Let me know if I need to resubmit.

Let me know if you have any questions.