### PR TITLE
Docker: Prevent docker-ce from being upgraded

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -22,6 +22,11 @@
     update_cache: yes
     force: yes
 
+- name: Prevent docker-ce from being upgraded
+  dpkg_selections:
+    name: docker-ce
+    selection: hold
+
 - name: Check docker daemon.json exists
   stat:
     path: /etc/docker/daemon.json


### PR DESCRIPTION
Now when you apt-get update, docker will not update.

Ref:
https://askubuntu.com/a/18656
http://docs.ansible.com/ansible/latest/apt_module.html