### PR TITLE
Common: Installs netaddr Python module

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -46,8 +46,9 @@
   with_items:
     - docker-py
     - certbot
-    - "ansible-toolbox"
+    - ansible-toolbox
     - dnspython
+    - netaddr
 
 - name: Install common npm modules
   npm: "name={{item}} global=yes"


### PR DESCRIPTION
- used by Ansible's `ipv4` filter.