### PR TITLE
docker: Better log size management

### DIFF
--- a/roles/docker/files/daemon.json
+++ b/roles/docker/files/daemon.json
@@ -1,4 +1,6 @@
 {
     "storage-driver": "overlay2",
-    "userland-proxy": false
+    "userland-proxy": false,
+    "log-driver": "json-file",
+    "log-opts": {"max-size": "10m", "max-file": "3"}
 }


### PR DESCRIPTION
This will control the log size. Requires a restart of the daemon and a re-run of the playbooks for it to take affect.