### PR TITLE
Add sickbeard_mp4_automator role

### DIFF
--- a/cloudbox.yml
+++ b/cloudbox.yml
@@ -60,3 +60,4 @@
     - { role: sabnzbd, tags: ['sabnzbd'] }
     - { role: nginx, tags: ['nginx'] }
     - { role: organizrv1, tags: ['organizrv1'] }
+    - { role: sickbeard_mp4_automator, tags: ['sickbeard_mp4_automator'] }

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -1,8 +1,9 @@
 #########################################################################
 # Title:         Cloudbox: Radarr Role                                  #
-# Author(s):     L3uddz, Desimaniac                                     #
+# Author(s):     L3uddz, Desimaniac, andrewkhunn                        #
 # URL:           https://github.com/cloudbox/cloudbox                   #
 # Docker Image:  hotio/suitarr                                          #
+#                andrewkhunn/suitarr_mp4_automator                      #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -66,10 +67,25 @@
       - "/mnt:/mnt"
       - "/mnt/unionfs/Media/Movies:/movies"
 
+- name: Check if sickbeard_mp4_automator is installed
+  stat:
+    path: /opt/scripts/sickbeard_mp4_automator
+  register: sma
+
+- name: Set default image to be installed
+  set_fact:
+    image: hotio/suitarr
+  when: sma.stat.isdir is not defined
+
+- name: Set sickbeard_mp4_automator image if present
+  set_fact:
+    image: andrewkhunn/suitarr_mp4_automator
+  when: sma.stat.isdir is defined and sma.stat.isdir
+
 - name: Create and start container
   docker_container:
     name: radarr
-    image: hotio/suitarr:radarr
+    image: "{{image}}:radarr"
     pull: yes
     published_ports:
       - "127.0.0.1:7878:7878"

--- a/roles/sickbeard_mp4_automator/tasks/main.yml
+++ b/roles/sickbeard_mp4_automator/tasks/main.yml
@@ -1,0 +1,65 @@
+#########################################################################
+# Title:         Cloudbox: sickbeard_mp4_automator Role                 #
+# Author(s):     andrewkhunn                                            #
+# URL:           https://github.com/cloudbox/cloudbox                   #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.rocks          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Create sickbeard_mp4_automator directories
+  file: "path={{item}} state=directory mode=0775 owner={{user}} group={{user}} recurse=yes"
+  with_items:
+    - /opt/scripts/sickbeard_mp4_automator
+
+- name: Clone sickbeard_mp4_automator
+  git:
+    repo: https://github.com/mdhiggins/sickbeard_mp4_automator
+    dest: /opt/scripts/sickbeard_mp4_automator
+    version: master
+    force: yes
+
+- name: Import sample config
+  template:
+    src: autoProcess.ini.default
+    dest: /opt/scripts/sickbeard_mp4_automator/autoProcess.ini.default
+    force: yes
+
+- name: Delete post_process extras
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items:
+    - /opt/scripts/sickbeard_mp4_automator/post_process/iTunes.py
+    - /opt/scripts/sickbeard_mp4_automator/post_process/sample.bat
+    - /opt/scripts/sickbeard_mp4_automator/post_process/sample.py
+    - /opt/scripts/sickbeard_mp4_automator/post_process/resources/add_to_iTunes.scpt
+    - /opt/scripts/sickbeard_mp4_automator/post_process/resources/iTunes.bat
+
+- name: Import plex_autoscan.py
+  template:
+    src: plex_autoscan.py.default
+    dest: /opt/scripts/sickbeard_mp4_automator/post_process/plex_autoscan.py
+    force: no
+
+- name: Set directory permissions
+  file: "path=/opt/scripts/sickbeard_mp4_automator state=directory owner={{user}} group={{user}} recurse=yes"
+
+- name: Check if media managers are installed
+  stat:
+    path: /opt/{{item}}
+  register: "{{item}}"
+  with_items:
+    - radarr
+    - sonarr
+
+- name: Reinstall Radarr to switch image to suitarr_mp4_automator
+  include_role:
+    name: radarr
+  when: radarr.stat.isdir is defined and radarr.stat.isdir
+
+- name: Reinstall Sonarr to switch image to suitarr_mp4_automator
+  include_role:
+    name: sonarr
+  when: sonarr.stat.isdir is defined and sonarr.stat.isdir

--- a/roles/sickbeard_mp4_automator/templates/autoProcess.ini.default
+++ b/roles/sickbeard_mp4_automator/templates/autoProcess.ini.default
@@ -1,0 +1,141 @@
+[SickBeard]
+host = localhost
+port = 8081
+username =
+password =
+web_root =
+ssl = False
+api_key =
+
+[Sonarr]
+host = localhost
+port = 8989
+web_root =
+ssl = False
+apikey =
+
+[Radarr]
+host = localhost
+port = 7878
+web_root =
+ssl = False
+apikey =
+
+[MP4]
+ffmpeg = /usr/bin/ffmpeg
+ffprobe = /usr/bin/ffprobe
+threads = 0
+output_directory =
+copy_to =
+move_to =
+output_extension = mp4
+output_format = mp4
+delete_original = True
+relocate_moov = True
+video-codec = h264, x264
+video-bitrate =
+video-crf =
+video-max-width =
+video-profile =
+h264-max-level = 4.1
+use-qsv-decoder-with-encoder = True
+use-hevc-qsv-decoder = False
+enable_dxva2_gpu_decode = False
+ios-audio = True
+ios-first-track-only = True
+ios-audio-filter = pan=stereo|c0=0.25*c0+c2+0.6*c3|c1=0.25*c1+c2+0.6*c3
+ios-move-last = True
+max-audio-channels =
+audio-codec = ac3, aac
+audio-language =
+audio-default-language =
+audio-channel-bitrate =
+audio-filter =
+audio-copy-original = False
+audio-first-track-of-language = False
+subtitle-codec = mov_text
+subtitle-language =
+subtitle-default-language =
+subtitle-encoding =
+fullpathguess = True
+convert-mp4 = True
+tagfile = True
+tag-language = eng
+download-artwork = Poster
+download-subs = False
+embed-subs = True
+embed-only-internal-subs = False
+sub-providers = addic7ed,podnapisi,thesubdb,opensubtitles
+permissions = 0777
+post-process = True
+pix-fmt =
+aac_adtstoasc = False
+preopts =
+postopts = -movflags, faststart
+
+[CouchPotato]
+host = localhost
+port = 5050
+username =
+password =
+web_root =
+ssl = False
+apikey =
+delay = 65
+method = renamer
+delete_failed = False
+
+[uTorrent]
+convert =
+couchpotato-label = couchpotato
+sickbeard-label = sickbeard
+sonarr-label = sonarr
+bypass-label = bypass
+sickrage-label = sickrage
+webui = False
+action_before = stop
+action_after = removedata
+host = http://localhost:8080/
+username =
+password =
+output_directory =
+
+[Deluge]
+host = localhost
+username =
+convert = True
+password =
+sonarr-label = sonarr
+bypass-label = bypass
+sickbeard-label = sickbeard
+port = 58846
+sickrage-label = sickrage
+couchpotato-label = couchpotato
+output_directory =
+remove = false
+
+[SABNZBD]
+convert = True
+sickrage-category = sickrage
+sonarr-category = sonarr
+radarr-category = radarr
+bypass-category = bypass
+couchpotato-category = couchpotato
+sickbeard-category = sickbeard
+output_directory =
+
+[Sickrage]
+host = localhost
+port = 8081
+username =
+password =
+web_root =
+ssl = False
+api_key =
+
+[Plex]
+host = localhost
+port = 32400
+refresh = True
+token =
+

--- a/roles/sickbeard_mp4_automator/templates/plex_autoscan.py.default
+++ b/roles/sickbeard_mp4_automator/templates/plex_autoscan.py.default
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+import os
+import json
+import requests
+
+def main():
+  print("plex_autoscan Post-processing Script")
+  url = "PLEX_AUTOSCAN_URL"
+
+  files = json.loads(os.environ.get('MH_FILES'))
+  if not (files):
+    print("Error - Did not find environment variables.")
+    return
+
+  for filename in files:
+    dirname = os.path.dirname(filename)
+    payload = {'eventType': 'Manual', 'filepath': dirname}
+    try:
+      requests.post(url, json=payload)
+    except Exception as e:
+      print("Error - Request failed.")
+      print(e)
+
+if __name__ == "__main__":
+  main()

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -1,8 +1,9 @@
 #########################################################################
 # Title:         Cloudbox: Sonarr Role                                  #
-# Author(s):     L3uddz, Desimaniac                                     #
+# Author(s):     L3uddz, Desimaniac, andrewkhunn                        #
 # URL:           https://github.com/cloudbox/cloudbox                   #
 # Docker Image:  hotio/suitarr                                          #
+#                andrewkhunn/suitarr_mp4_automator                      #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -66,10 +67,25 @@
       - "/mnt:/mnt"
       - "/mnt/unionfs/Media/TV:/tv"
 
+- name: Check if sickbeard_mp4_automator is installed
+  stat:
+    path: /opt/scripts/sickbeard_mp4_automator
+  register: sma
+
+- name: Set default image to be installed
+  set_fact:
+    image: hotio/suitarr
+  when: sma.stat.isdir is not defined
+
+- name: Set sickbeard_mp4_automator image if present
+  set_fact:
+    image: andrewkhunn/suitarr_mp4_automator
+  when: sma.stat.isdir is defined and sma.stat.isdir
+
 - name: Create and start container
   docker_container:
     name: sonarr
-    image: "hotio/suitarr:sonarr"
+    image: "{{image}}:sonarr"
     pull: yes
     published_ports:
       - "127.0.0.1:8989:8989"


### PR DESCRIPTION
This is a much more robust solution than my first go-round. The linked image for Sonarr and Radarr is merely [`hotio/suitarr` with the sickbeard_mp4_automator dependencies installed](https://hub.docker.com/r/andrewkhunn/suitarr_mp4_automator/~/dockerfile/). It's also linked to `hotio/suitarr`, so anytime that image is updated, my edit will rebuild as well.

All the instructions I offered on my last PR will still work to test this. In brief:

> Basically, the PR should be fully operational. Install sickbeard_mp4_automator which will automagically rerun the radarr/sonarr roles (if detected) to switch the docker image used.
> 
> To enable mp4 conversion, all you need to do is change the plex_autoscan Connect script to only fire 'On Rename'. Then add a 'Custom Script' to fire ' On Download' and 'On Upgrade' and point it to either `/scripts/sickbeard_mp4_automator/postSonarr.py` or `/scripts/sickbeard_mp4_automator/postRadarr.py`. Finally, edit `/scripts/sickbeard_mp4_automator/autoProcess.ini.default`, add your Sonarr and Radarr API keys in the appropriate sections, and save as `autoProcess.ini` and edit `/scripts/sickbeard_mp4_automator/post_process/plex_autoscan.py` and add your plex_autoscan URL.
> 
> - [Connect tab after implementation](https://imgur.com/0EKNhhC)
> - [Custom Script dialog](https://imgur.com/nSx6if3)
> 
> This will now be the order of operations once a download is handed back to Sonarr/Radarr from NZBGet/ruTorrent:
> 
> 1. Sonarr/Radarr renames the file and executes the sickbeard_mp4_automator Connect script
> 2. sickbeard_mp4_automator runs, converts the renamed file to an mp4 following the config in `autoProcess.ini`, and deletes the original file
> 3. sickbeard_mp4_automator executes the `/scripts/sickbeard_mp4_automator/post_process/plex_autoscan.py` script notifying plex_autoscan to scan the new files' directory
> 4. sickbeard_mp4_automator notifies Sonarr/Radarr of the new filename and initiates a rescan of the file location to pick up the change

I _would_ like to get the automatic insertion of the `plex_autoscan` url into `plex_autoscan.py` working, but making the required edits to `plex_autoscan_url.sh` is really beyond what I am comfortable hacking on, so I'll either wait for @desimaniac  to get around to it, or cobble something together at some point in the future.