### PR TITLE
add optional call 'cloudplow upload' to backup role

### DIFF
--- a/defaults/backup_config.yml.default
+++ b/defaults/backup_config.yml.default
@@ -14,3 +14,5 @@ cron:
 vault_service:
   user:
   pass:
+cloudplow_upload:
+  enabled: false

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -157,6 +157,10 @@
       cloudplow_service_running: "{{ (services['cloudplow.service'] is defined) and (services['cloudplow.service']['state'] == \"running\") }}"
     when: cloudplow_service.stat.exists
 
+  - name: "Execute 'cloudplow upload'"
+    shell: "cloudplow upload"
+    when: cloudplow_upload.enabled and cloudplow_service.stat.exists and cloudplow_service_running
+
   - name: Stop cloudplow service
     systemd:
       name: cloudplow

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -160,7 +160,8 @@
   - name: "Execute 'cloudplow upload'"
     shell: "cloudplow upload"
     when: cloudplow_upload.enabled and cloudplow_service.stat.exists and cloudplow_service_running
-
+    ignore_errors: yes
+      
   - name: Stop cloudplow service
     systemd:
       name: cloudplow


### PR DESCRIPTION
I thought this might be a nice, configurable feature to add to the backup process. While not always the case, if someone makes a backup of cloudbox, prior to wiping their server, but forgets to execute a manual cloudplow upload with say ~150gigs of local media, it creates a bit of  a headache. It would be convenient if, as part of the backup process, cloudplow would perform a forced upload (if enabled). 