### PR TITLE
Common: Only add APT multiverse repo when running Ubuntu

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,6 +32,7 @@
     - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
     - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
   register: apt_multiverse_repositories
+  when: ansible_distribution == 'Ubuntu'
 
 - name: Update APT packages list
   apt:


### PR DESCRIPTION
When running a fresh installation on Debian Stretch, an unsupported distribution, the addition of Ubuntu specific repositories is not needed. Leaving these enabled causes a failed playbook run.

`cloudbox git:(master) sudo ansible-playbook cloudbox.yml -b --tags mediabox`

<snip>

`TASK [common : Add multiverse repositories] *************************************************************
Wednesday 19 December 2018  21:08:24 -0500 (0:00:02.102)       0:01:22.175 **** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: apt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file.
failed: [localhost] (item=deb http://archive.ubuntu.com/ubuntu stretch multiverse) => {"changed": false, "item": "deb http://archive.ubuntu.com/ubuntu stretch multiverse", "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_4ciYqR/ansible_module_apt_repository.py\", line 551, in <module>\n    main()\n  File \"/tmp/ansible_4ciYqR/ansible_module_apt_repository.py\", line 543, in main\n    cache.update()\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 464, in update\n    raise FetchFailedException(e)\napt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file.\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: apt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file.
failed: [localhost] (item=deb-src http://archive.ubuntu.com/ubuntu stretch multiverse) => {"changed": false, "item": "deb-src http://archive.ubuntu.com/ubuntu stretch multiverse", "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_WE2ZgR/ansible_module_apt_repository.py\", line 551, in <module>\n    main()\n  File \"/tmp/ansible_WE2ZgR/ansible_module_apt_repository.py\", line 543, in main\n    cache.update()\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 464, in update\n    raise FetchFailedException(e)\napt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file.\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: apt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'http://archive.ubuntu.com/ubuntu stretch-updates Release' does not have a Release file.
failed: [localhost] (item=deb http://archive.ubuntu.com/ubuntu stretch-updates multiverse) => {"changed": false, "item": "deb http://archive.ubuntu.com/ubuntu stretch-updates multiverse", "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Vfrx0q/ansible_module_apt_repository.py\", line 551, in <module>\n    main()\n  File \"/tmp/ansible_Vfrx0q/ansible_module_apt_repository.py\", line 543, in main\n    cache.update()\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 464, in update\n    raise FetchFailedException(e)\napt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'http://archive.ubuntu.com/ubuntu stretch-updates Release' does not have a Release file.\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: apt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'http://archive.ubuntu.com/ubuntu stretch-updates Release' does not have a Release file.
failed: [localhost] (item=deb-src http://archive.ubuntu.com/ubuntu stretch-updates multiverse) => {"changed": false, "item": "deb-src http://archive.ubuntu.com/ubuntu stretch-updates multiverse", "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_s2vXY9/ansible_module_apt_repository.py\", line 551, in <module>\n    main()\n  File \"/tmp/ansible_s2vXY9/ansible_module_apt_repository.py\", line 543, in main\n    cache.update()\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 464, in update\n    raise FetchFailedException(e)\napt.cache.FetchFailedException: E:The repository 'http://archive.ubuntu.com/ubuntu stretch Release' does not have a Release file., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'http://archive.ubuntu.com/ubuntu stretch-updates Release' does not have a Release file.\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}`