### PR TITLE
Added support for Plexdrive 4

### DIFF
--- a/cloudbox.yml
+++ b/cloudbox.yml
@@ -12,7 +12,7 @@
     - { role: backup, tags: ['backup'] }
     - { role: restore, tags: ['restore'] }
     - { role: user, tags: ['core', 'cloudbox', 'mediabox', 'feederbox', 'user'] }
-    - { role: shell, tags: ['core', 'cloudbox', 'mediabox', 'feederbox'], 'shell' }
+    - { role: shell, tags: ['core', 'cloudbox', 'mediabox', 'feederbox', 'shell'] }
     - { role: kernel, tags: ['core', 'cloudbox', 'mediabox', 'feederbox', 'kernel'] }
     - { role: pre_install, tags: ['core', 'cloudbox', 'mediabox', 'feederbox'] }
     - { role: system, tags: ['core', 'cloudbox', 'mediabox', 'feederbox', 'system'] }

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -12,3 +12,5 @@ plex:
 rclone:
   version: latest
 shell: zsh
+plexdrive:
+  version: 5.0.0

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -22,6 +22,7 @@
     - "/opt/plex/Library"
     - "/opt/plex/Library/Application Support"
     - "/opt/plex/Library/Application Support/Plex Media Server"
+    - "/opt/plex/Library/Application Support/Plex Media Server/Plug-ins"
     - "/opt/plex/Library/Logs"
     - "/opt/plex/Library/Logs/Plex Media Server"
     - "{{plex.transcodes}}"
@@ -175,11 +176,6 @@
     group: "{{user}}"
     mode: 0775
     recurse: yes
-
-- name: "Wait for 'Plug-ins' folder to be created by Plex"
-  wait_for:
-    path: "/opt/plex/Library/Application Support/Plex Media Server/Plug-ins"
-    state: present
 
 - name: "Install WebTools"
   import_role:

--- a/roles/plexdrive/tasks/main.yml
+++ b/roles/plexdrive/tasks/main.yml
@@ -36,9 +36,15 @@
     - /opt/plexdrive
     - /mnt/plexdrive
 
+- name: Install mongodb
+  apt:
+    name: mongodb
+    state: present
+  when: plexdrive.version == '4.0.0'
+
 - name: Install plexdrive
   get_url:
-    url:  https://github.com/dweidenfeld/plexdrive/releases/download/5.0.0/plexdrive-linux-amd64
+    url:  https://github.com/dweidenfeld/plexdrive/releases/download/{{plexdrive.version}}/plexdrive-linux-amd64
     dest: /opt/plexdrive/plexdrive
     mode: 0775
     owner: "{{user}}"
@@ -51,7 +57,6 @@
     src: plexdrive.service.js2
     dest: /etc/systemd/system/plexdrive.service
     force: yes
-  when: not plexdrive_service.stat.exists
 
 - name: Systemd daemon-reload
   systemd: state=stopped name=plexdrive daemon_reload=yes enabled=no

--- a/roles/plexdrive/templates/plexdrive.service.js2
+++ b/roles/plexdrive/templates/plexdrive.service.js2
@@ -9,10 +9,13 @@ User={{user}}
 Group={{user}}
 Type=simple
 ExecStartPre=/bin/sleep 10
+{% if plexdrive.version == '5.0.0' %}
 ExecStart=/opt/plexdrive/plexdrive mount -v 3 --refresh-interval=1m --chunk-check-threads=8 --chunk-load-threads=8 --chunk-load-ahead=4 --chunk-size=10M --max-chunks={{ ((ansible_memory_mb.real.total/1024)|round(0,'ceil')|int >= 16) | ternary(250,150) }} --fuse-options=allow_other,read_only --config=/opt/plexdrive --cache-file=/opt/plexdrive/cache.bolt /mnt/plexdrive
+{% elif plexdrive.version == '4.0.0' %}
+ExecStart=/opt/plexdrive/plexdrive /mnt/plexdrive -v 3 --refresh-interval=1m --fuse-options=allow_other,read_only,allow_non_empty_mount --config=/opt/plexdrive
+{% endif %}
 ExecStop=/bin/fusermount -uz /mnt/plexdrive
-Restart=always
-RestartSec=5
+Restart=on-abort
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
I've tweaked the Plexdrive role to include the option for Plexdrive 4. I have had many problems using Plexdrive 5 on any machine with less than 16GB. Reading other users who faced similar issues, I migrated to Plexdrive 4 and found it to be much more stable.

The default version is 5, but those requiring version 4 can change this in settings.yml.default.