### PR TITLE
Disable Copy-on-Write for /mnt and /opt if btrfs is found

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -22,6 +22,22 @@
     - /mnt/local/Media/TV
     - /opt
 
+- name: "Determine '/' filesystem type"
+  set_fact:
+    root_fstype: "{{ item.fstype }}"
+  when: "(item.mount == '/')"
+  with_items:
+    - "{{ ansible_mounts }}"
+
+- name: Set no-cow on '/opt' and '/mnt' if '/' is btrfs
+  file: "path={{item}}"
+  attributes: "+C"
+  recurse: yes
+  when: root_fstype == 'btrfs'
+  with_items:
+    - /mnt
+    - /opt
+
 - name: Add multiverse repositories
   apt_repository:
     repo: "{{item}}"


### PR DESCRIPTION
The disable will only cover new files so any existing files that are already there are stuck with cow enabled.  If this is called on a net new install then it'll obviously cover all files in the dirs. The only way to cover on existing files would be to move off the dirs, create new ones and copy the files back in but I thought that might not be an issue considering people havent moved to btrfs yet.