### PR TITLE
Feature/intel gpu tools

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -48,6 +48,10 @@
   when: apt_multiverse_repositories.changed
   ignore_errors: yes
 
+- name: Fetch pci info
+  shell: "lspci -v -s $(lspci | grep -E '.*VGA.*Intel.*' | cut -d' ' -f 1) 2>/dev/null || :"
+  register: lscpi_resp
+
 - name: Install common packages
   apt: "name={{item}} state=present"
   with_items:
@@ -80,6 +84,7 @@
     - apache2-utils
     - jq
     - lib32z1
+    - "{{ 'intel-gpu-tools' if ('i915' in lscpi_resp.stdout) | default(false) else omit }}"
   ignore_errors: yes
 
 - name: Install unrar

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -53,38 +53,39 @@
   register: lscpi_resp
 
 - name: Install common packages
-  apt: "name={{item}} state=present"
+  apt: "name={{item.package}} state=present"
   with_items:
-    - nano
-    - zip
-    - unzip
-    - p7zip
-    - curl
-    - httpie
-    - sqlite3
-    - tree
-    - lsof
-    - man-db
-    - ksmtuned
-    - git
-    - pwgen
-    - rsync
-    - logrotate
-    - htop
-    - iotop
-    - nload
-    - fail2ban
-    - ufw
-    - ncdu
-    - mc
-    - speedtest-cli
-    - dnsutils
-    - screen
-    - tmux
-    - apache2-utils
-    - jq
-    - lib32z1
-    - "{{ 'intel-gpu-tools' if ('i915' in lscpi_resp.stdout) | default(false) else omit }}"
+    - { package: "nano" }
+    - { package: "zip" }
+    - { package: "unzip" }
+    - { package: "p7zip" }
+    - { package: "curl" }
+    - { package: "httpie" }
+    - { package: "sqlite3" }
+    - { package: "tree" }
+    - { package: "lsof" }
+    - { package: "man-db" }
+    - { package: "ksmtuned" }
+    - { package: "git" }
+    - { package: "pwgen" }
+    - { package: "rsync" }
+    - { package: "logrotate" }
+    - { package: "htop" }
+    - { package: "iotop" }
+    - { package: "nload" }
+    - { package: "fail2ban" }
+    - { package: "ufw" }
+    - { package: "ncdu" }
+    - { package: "mc" }
+    - { package: "speedtest-cli" }
+    - { package: "dnsutils" }
+    - { package: "screen" }
+    - { package: "tmux" }
+    - { package: "apache2-utils" }
+    - { package: "jq" }
+    - { package: "lib32z1" }
+    - { package: "intel-gpu-tools", skip: "{{ 'i915' not in lscpi_resp.stdout }}" }
+  when: not item.skip | default(False) | bool
   ignore_errors: yes
 
 - name: Install unrar


### PR DESCRIPTION
Install intel-gpu-tools when an Intel VGA device is present.

This will provide access to intel_gpu_top which can be used to monitor the iGPU's activity.