### PR TITLE
TorrentCleanup: Sonarr V3 Test

### DIFF
--- a/roles/scripts/files/TorrentCleanup.py
+++ b/roles/scripts/files/TorrentCleanup.py
@@ -104,7 +104,7 @@ log = logging.getLogger("TorrentCleanup")
 if len(sys.argv) <= 1:
     log.error("You must specify an argument of either sonarr/radarr/lidarr.")
     sys.exit(0)
-elif 'Sonarr_EvenType_Test':
+elif os.environ.get('sonarr_eventtype') == "Test":
     sys.exit(0)
 elif 'sonarr' in sys.argv[1].lower():
     sourceFile = os.environ.get('sonarr_episodefile_sourcepath')


### PR DESCRIPTION
Corrected the Sonarr V3 script test.
This allows Sonarr V3 to test the script correctly, without this the script will never run.
Sonarr V2 only tests for existance of file, it doesn't test anything within the script, hence why this is only required now with Sonarr V3.