### PR TITLE
Feature/emby and plex https redirect

### DIFF
--- a/defaults/adv_settings.yml.default
+++ b/defaults/adv_settings.yml.default
@@ -9,6 +9,7 @@ plex:
   force_auto_adjust_quality: no
   force_high_output_bitrates: no
   db_cache_size: default
+  http_redirect: no
 suitarr:
   version: default
 sonarr:
@@ -17,6 +18,7 @@ darkerr:
   enable: no
 emby:
   version: latest
+  http_redirect: no
 organizr:
   direct_domain: no
 nginx:

--- a/roles/emby/tasks/main.yml
+++ b/roles/emby/tasks/main.yml
@@ -64,7 +64,7 @@
       VIRTUAL_PORT: 8096
       LETSENCRYPT_HOST: "emby.{{ domain }}"
       LETSENCRYPT_EMAIL: "{{ email }}"
-      HTTPS_METHOD: noredirect
+      HTTPS_METHOD: "{{ 'redirect' if emby.http_redirect | default('noredirect') }}"
       NVIDIA_DRIVER_CAPABILITIES: "{{ 'compute,video,utility' if gpu.nvidia | default(false) else omit }}"
       NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
     volumes:

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -145,7 +145,7 @@
       VIRTUAL_PORT: 32400
       LETSENCRYPT_HOST: "plex.{{ domain }}"
       LETSENCRYPT_EMAIL: "{{ email }}"
-      HTTPS_METHOD: noredirect
+      HTTPS_METHOD: "{{ 'redirect' if emby.http_redirect | default('noredirect') }}"
       HEALTHCHECK_MOUNT: /mnt/unionfs
       NVIDIA_DRIVER_CAPABILITIES: "{{ 'compute,video,utility' if gpu.nvidia | default(false) else omit }}"
       NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -145,7 +145,7 @@
       VIRTUAL_PORT: 32400
       LETSENCRYPT_HOST: "plex.{{ domain }}"
       LETSENCRYPT_EMAIL: "{{ email }}"
-      HTTPS_METHOD: "{{ 'redirect' if emby.http_redirect | default('noredirect') }}"
+      HTTPS_METHOD: "{{ 'redirect' if plex.http_redirect | default('noredirect') }}"
       HEALTHCHECK_MOUNT: /mnt/unionfs
       NVIDIA_DRIVER_CAPABILITIES: "{{ 'compute,video,utility' if gpu.nvidia | default(false) else omit }}"
       NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"


### PR DESCRIPTION
Defaults to previous / existing / current behaviour
Enables adv_settings.yml control to enable https redirection instead of passthrough