### PR TITLE
Vagrantfile for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,19 @@
 
 # Python
 *.pyc
+
+# Created by https://www.gitignore.io/api/vagrant
+# Edit at https://www.gitignore.io/?templates=vagrant
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.logs
+
+### Vagrant Patch ###
+*.box
+
+
+# End of https://www.gitignore.io/api/vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,18 @@
-# Cloudbox
+### Vagrant ###
+.vagrant/
+*.box
+
+### MacOS ###
+.DS_Store
+
+### Python ###
+*.pyc
+
+### Ansible ###
+/backup.lock
+/cloudbox.retry
+
+### Cloudbox ###
 /ansible.cfg
 /accounts.yml
 /settings.yml
@@ -7,29 +21,3 @@
 /backup_config.yml
 /backup_excludes_list.txt
 /*.log
-
-# Ansible
-/backup.lock
-/cloudbox.retry
-
-# MacOS
-.DS_Store
-
-# Python
-*.pyc
-
-# Created by https://www.gitignore.io/api/vagrant
-# Edit at https://www.gitignore.io/?templates=vagrant
-
-### Vagrant ###
-# General
-.vagrant/
-
-# Log files (if you are creating logs in debug mode, uncomment this)
-# *.logs
-
-### Vagrant Patch ###
-*.box
-
-
-# End of https://www.gitignore.io/api/vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,18 @@
 $script = <<-SCRIPT
-cd ~/Cloudbox
+cd ~/cloudbox
 for f in defaults/*.default; do base=${f##*/} base=${base%.default}; cp -n -- "$f" "$base"; done
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.synced_folder ".", "/home/vagrant/Cloudbox", disabled: false
   config.vm.synced_folder ".", "/vagrant", disabled: false
+  config.vm.synced_folder ".", "/home/vagrant/cloudbox", disabled: false, create: true
   config.vm.provision "shell", path: "https://cloudbox.works/scripts/dep.sh"
   config.vm.provision "shell", privileged: false, inline: $script
-  config.vm.provision "ansible_local" do |ansible|
+  config.vm.provision "ansible_local", run: "always" do |ansible|
     ansible.compatibility_mode = "2.0"
-    ansible.inventory_path = "/home/vagrant/Cloudbox/inventories/local"
+    ansible.inventory_path = "/home/vagrant/cloudbox/inventories/local"
     ansible.limit = "all"
-    ansible.playbook = "/home/vagrant/Cloudbox/cloudbox.yml"
+    ansible.playbook = "/home/vagrant/cloudbox/cloudbox.yml"
     ansible.become = true
     # ansible.verbose Examples: false, true (equivalent to v), -vvv (equivalent to vvv), vvvv.
     ansible.verbose = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ SCRIPT
 
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: false
-  config.vm.synced_folder ".", "/home/vagrant/cloudbox", disabled: false, create: true
+  config.vm.synced_folder ".", "/home/vagrant/cloudbox", disabled: false
   config.vm.provision "shell", path: "https://cloudbox.works/scripts/dep.sh"
   config.vm.provision "shell", privileged: false, inline: $script
   config.vm.provision "ansible_local", run: "always" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.provision "ansible" do |ansible|
+    ansible.compatibility_mode = "2.0"
+    ansible.verbose = "y"
+    ansible.playbook = "vagrant.yml"
+    ansible.limit = "all"
+    ansible.become = true
+  end
+
+  config.vm.define "ubuntu18" do |ubuntu18|
+    ubuntu18.vm.box = "geerlingguy/ubuntu1804"
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,16 +10,21 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", privileged: false, inline: $script
   config.vm.provision "ansible_local" do |ansible|
     ansible.compatibility_mode = "2.0"
-    ansible.verbose = "y"
-    ansible.playbook = "/home/vagrant/Cloudbox/cloudbox.yml"
-    ansible.tags = "cloudbox"
+    ansible.inventory_path = "/home/vagrant/Cloudbox/inventories/local"
     ansible.limit = "all"
+    ansible.playbook = "/home/vagrant/Cloudbox/cloudbox.yml"
     ansible.become = true
+    # ansible.verbose Examples: false, true (equivalent to v), -vvv (equivalent to vvv), vvvv.
+    ansible.verbose = false
+    ansible.tags = "cloudbox"
+    ansible.skip_tags = "settings"
+    ansible.extra_vars = { continuous_integration: true }
+
   end
-  config.vm.define "ubuntu18" do |ubuntu18|
-    ubuntu18.vm.box = "generic/ubuntu1804"
-  end
-  # config.vm.define "ubuntu16" do |ubuntu16|
-  #   ubuntu16.vm.box = "generic/ubuntu1604"
-  # end
+#  config.vm.define "ubuntu18" do |ubuntu18|
+#    ubuntu18.vm.box = "generic/ubuntu1804"
+#  end
+   config.vm.define "ubuntu16" do |ubuntu16|
+     ubuntu16.vm.box = "generic/ubuntu1604"
+   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,25 @@
+$script = <<-SCRIPT
+cd ~/Cloudbox
+for f in defaults/*.default; do base=${f##*/} base=${base%.default}; cp -- "$f" "$base"; done
+SCRIPT
+
 Vagrant.configure("2") do |config|
-  config.vm.provision "ansible" do |ansible|
+  config.vm.synced_folder ".", "/home/vagrant/Cloudbox", disabled: false
+  config.vm.synced_folder ".", "/vagrant", disabled: false
+  config.vm.provision "shell", path: "https://cloudbox.works/scripts/dep.sh"
+  config.vm.provision "shell", privileged: false, inline: $script
+  config.vm.provision "ansible_local" do |ansible|
     ansible.compatibility_mode = "2.0"
     ansible.verbose = "y"
-    ansible.playbook = "vagrant.yml"
+    ansible.playbook = "/home/vagrant/Cloudbox/cloudbox.yml"
+    ansible.tags = "cloudbox"
     ansible.limit = "all"
     ansible.become = true
   end
-
   config.vm.define "ubuntu18" do |ubuntu18|
-    ubuntu18.vm.box = "geerlingguy/ubuntu1804"
+    ubuntu18.vm.box = "generic/ubuntu1804"
   end
+  # config.vm.define "ubuntu16" do |ubuntu16|
+  #   ubuntu16.vm.box = "generic/ubuntu1604"
+  # end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 $script = <<-SCRIPT
 cd ~/Cloudbox
-for f in defaults/*.default; do base=${f##*/} base=${base%.default}; cp -- "$f" "$base"; done
+for f in defaults/*.default; do base=${f##*/} base=${base%.default}; cp -n -- "$f" "$base"; done
 SCRIPT
 
 Vagrant.configure("2") do |config|

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,5 +1,0 @@
----
-- hosts: all
-  become: true
-  roles:
-   - security

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: true
+  roles:
+   - security


### PR DESCRIPTION
This is a Vagrantfile for use and local development, some lines are added to .gitignore to facilitate the addition.

Vagrantfile should be usable with most local provisioners e.g. Parrallels, VBox and vmware_desktop.
It contains boxes for both Ubuntu 16.04 and Ubuntu 18.04. 

Cavecats: You might want to disable the ``` config.vm.provision "shell",``` Lines after first run to drasticly, improve speed and to avoid re-writing configs.
