### PR TITLE
use qoutes in watchtower role.

### DIFF
--- a/roles/watchtower/tasks/main.yml
+++ b/roles/watchtower/tasks/main.yml
@@ -19,7 +19,7 @@
     name: watchtower
     image: "v2tec/watchtower"
     pull: yes
-    command: “--cleanup”
+    command: "--cleanup"
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
This should close #298.

The quotes used, is not ansible standard, thus they are considered part of the string rather than, quotes.