### PR TITLE
Do not replace 'null' in the middle of a word

### DIFF
--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
@@ -50,8 +50,8 @@
 - name: Migrator | 'accounts.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: 'null'
-    replace: ''
+    regexp: '(\s*.*):\s*null'
+    replace: '\1: '
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
@@ -51,8 +51,8 @@
 - name: Migrator | 'accounts.yml' | Migration 02 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: 'null'
-    replace: ''
+    regexp: '(\s*.*):\s*null'
+    replace: '\1: '
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/backup_config_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/backup_config_yml/migration_01.yml
@@ -64,8 +64,8 @@
 - name: Migrator | 'backup_config.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: 'null'
-    replace: ''
+    regexp: '(\s*.*):\s*null'
+    replace: '\1: '
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664


### PR DESCRIPTION
If a username, email, or password in accounts.yml or backup_config.yml has 'null' in the middle of a word, it will be silently replaced and the user will end up wondering why their account does not authenticate.

This change makes the replace rule match and replace a line like `'property: null'` but not match `'property: nully-mcnullface'`.