### PR TITLE
Ignore null when it's the start of a longer string

### DIFF
--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
@@ -50,7 +50,7 @@
 - name: Migrator | 'accounts.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null'
+    regexp: '(\s*.*):\s*null\b'
     replace: '\1: '
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"

--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
@@ -51,7 +51,7 @@
 - name: Migrator | 'accounts.yml' | Migration 02 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null'
+    regexp: '(\s*.*):\s*null\b'
     replace: '\1: '
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"


### PR DESCRIPTION
Prevents an error when a string starts with the text "null"
e.g. The domain nullsoft.com is truncated to soft.com