### PR TITLE
Made null replacmement more specific

### DIFF
--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_01.yml
@@ -50,8 +50,8 @@
 - name: Migrator | 'accounts.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null\b'
-    replace: '\1: '
+    regexp: '(?<=: )\bnull\s*$'
+    replace: ''
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
+++ b/roles/settings/tasks/subtasks/migrator/accounts_yml/migration_02.yml
@@ -51,8 +51,8 @@
 - name: Migrator | 'accounts.yml' | Migration 02 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null\b'
-    replace: '\1: '
+    regexp: '(?<=: )\bnull\s*$'
+    replace: ''
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/adv_settings_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/adv_settings_yml/migration_01.yml
@@ -53,8 +53,8 @@
 - name: Migrator | 'adv_settings.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null'
-    replace: '\1: '
+    regexp: '(?<=: )\bnull\s*$'
+    replace: ''
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/adv_settings_yml/migration_02.yml
+++ b/roles/settings/tasks/subtasks/migrator/adv_settings_yml/migration_02.yml
@@ -43,8 +43,8 @@
 - name: Migrator | 'adv_settings.yml' | Migration 02 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null'
-    replace: '\1: '
+    regexp: '(?<=: )\bnull\s*$'
+    replace: ''
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664

--- a/roles/settings/tasks/subtasks/migrator/backup_config_yml/migration_01.yml
+++ b/roles/settings/tasks/subtasks/migrator/backup_config_yml/migration_01.yml
@@ -64,8 +64,8 @@
 - name: Migrator | 'backup_config.yml' | Migration 01 | Remove 'null' values
   replace:
     path: "{{ playbook_dir }}/{{ file }}"
-    regexp: '(\s*.*):\s*null'
-    replace: '\1: '
+    regexp: '(?<=: )\bnull\s*$'
+    replace: ''
     owner: "{{ cloudbox_yml.stat.uid }}"
     group: "{{ cloudbox_yml.stat.gid }}"
     mode: 0664


### PR DESCRIPTION
Previous patch would fail on a null.tld domain or certain passwords with the string "null" at the start.

This makes the null regex more specific for only true null values. See https://regex101.com/r/YlxGLP/8 for details and test cases.