### PR TITLE
Add dkms to Nvidia install.

### DIFF
--- a/roles/nvidia/tasks/nvidia_driver.yml
+++ b/roles/nvidia/tasks/nvidia_driver.yml
@@ -14,6 +14,12 @@
     update_cache: yes
     state: present
 
+- name: Install 'dkms'
+  apt:
+    name: dkms
+    update_cache: yes
+    state: present
+
 - name: Set 'nvidia_driver_version' variable
   set_fact:
     nvidia_driver_version: >-
@@ -33,7 +39,7 @@
   register: driver_download
 
 - name: Install Nvidia drivers
-  shell: "/tmp/NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run --silent"
+  shell: "/tmp/NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run --dkms --silent"
   register: driver_install
   ignore_errors: yes
 


### PR DESCRIPTION
Added the --dkms option to the runfile installer so the driver doesn't need to be reinstalled when upgrading the kernel.