### PR TITLE
Change Tautulli to the stable release

### DIFF
--- a/roles/tautulli/defaults/main.yml
+++ b/roles/tautulli/defaults/main.yml
@@ -45,7 +45,7 @@ tautulli_docker_container: "{{ tautulli_name }}"
 
 # Image
 tautulli_docker_image_pull: yes
-tautulli_docker_image_tag: "nightly"
+tautulli_docker_image_tag: "latest"
 tautulli_docker_image: "tautulli/tautulli:{{ tautulli_docker_image_tag }}"
 
 # Ports


### PR DESCRIPTION
Change Tautulli to the stable release from the nightly one. The nightly release can break at any time and should not be used by anyone that isn't comfortable with that and able to diagnose issues with their installation.

Fixes #396.