### PR TITLE
Updated Trackarr config to fix undefined variable error

### DIFF
--- a/roles/trackarr/templates/config.yaml.j2
+++ b/roles/trackarr/templates/config.yaml.j2
@@ -2,8 +2,8 @@
 database:
   maxagehours: 72
 pvr:
-- name: "{{ sonarr_name }}"
-  url: "{{ sonarr_web_url }}"
+- name: "sonarr"
+  url: "https://sonarr.{{ user.domain }}"
   apikey: "{{ sonarr_api_key }}"
   enabled: true
   filters:
@@ -16,8 +16,8 @@ pvr:
       - any (Files, {% raw -%}{#{%- endraw %} matches "(?i)\\.(bdmv|mpls|miniso|cci|cer|clpi|m2ts|VOB|IFO|BUP|iso|rar|r01)$"})
     delays:
       - 'not (TorrentName contains "1080") ? 15 : 0'
-- name: "{{ radarr_name }}"
-  url: "{{ radarr_web_url }}"
+- name: "radarr"
+  url: "https://radarr.{{ user.domain }}"
   apikey: "{{ radarr_api_key }}"
   enabled: true
   filters:


### PR DESCRIPTION
Currently, ansible fails with:
```
TASK [trackarr : Pre-Install | Import default Trackarr config] 
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'sonarr_name' is undefined"}
```