### PR TITLE
Update Organizr Container + Variables

### DIFF
--- a/defaults/adv_settings.yml.default
+++ b/defaults/adv_settings.yml.default
@@ -21,6 +21,8 @@ darkerr:
   enable: no
 organizr:
   direct_domain: no
+  fpm: yes
+  branch: v2-develop
 nginx:
   direct_domain: no
   subdomain: web

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -171,3 +171,4 @@
     force: yes
     validate_certs: no
   ignore_errors: yes
+

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -69,8 +69,8 @@
     published_ports:
       - "127.0.0.1:7421:80"
     env:
-      fpm: "true"
-      branch: "v2-develop"
+      fpm: "{{ (organizr.fpm|default(false,true)) }}"
+      branch: "{{ (organizr.branch|default(false,true)) }}"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
       VIRTUAL_HOST: "{{ (organizr.direct_domain|default(false,true)) | ternary(user.domain + ',' + 'www.' + user.domain,'organizr.' + user.domain) }}"
@@ -95,13 +95,73 @@
     path: "/opt/organizr/www/Dashboard/css/themes/Organizr.css"
     state: present
 
-- name: Download Plex Theme
+- name: Download Gilbn Plex Theme
   get_url:
-    url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/organizr/plex.css"
+    url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/plex-base.css"
     dest: "/opt/organizr/www/Dashboard/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"
     mode: 0664
     force: yes
     validate_certs: no
+
+- name: Download Gilbn AquaMarine Theme
+  get_url:
+    url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/aquamarine.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+
+- name: Download Gilbn Dark Theme
+  get_url:
+    url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/plex/dark.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+
+- name: Download Gilbn Hotline Theme
+  get_url:
+    url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/hotline.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+
+- name: Download Gilbn Organizr Dark Theme
+  get_url:
+    url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/organizr-dark.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+
+- name: Download Gilbn Space Grey Theme
+  get_url:
+    url:  "https://github.com/gilbN/theme.park/blob/master/CSS/themes/plex/space-gray.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+
+- name: Download Burry Plex Theme
+  get_url: "https://raw.githubusercontent.com/Burry/organizr-v2-plex-theme/master/css/Plex.css"
+    dest: "/opt/organizr/www/Dashboard/css/themes/"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+    force: yes
+    validate_certs: no
+    
   ignore_errors: yes

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -104,7 +104,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Gilbn AquaMarine Theme
   get_url:
@@ -115,7 +115,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Gilbn Dark Theme
   get_url:
@@ -126,7 +126,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Gilbn Hotline Theme
   get_url:
@@ -137,7 +137,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Gilbn Organizr Dark Theme
   get_url:
@@ -148,7 +148,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Gilbn Space Grey Theme
   get_url:
@@ -159,7 +159,7 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes
 
 - name: Download Burry Plex Theme
   get_url: 
@@ -170,4 +170,4 @@
     mode: 0664
     force: yes
     validate_certs: no
-    ignore_errors: yes
+  ignore_errors: yes

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
 # Title:         Cloudbox: Organizr Role                                #
-# Author(s):     l3uddz, desimaniac                                     #
+# Author(s):     l3uddz, desimaniac, jonfinley                          #
 # URL:           https://github.com/cloudbox/cloudbox                   #
-# Docker Image:  lsiocommunity/organizr                                 #
+# Docker Image:  organizr/organizr                                      #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -64,11 +64,13 @@
 - name: Create and start container
   docker_container:
     name: organizr
-    image: "organizrtools/organizr-v2:plex"
+    image: "organizr/organizr"
     pull: yes
     published_ports:
       - "127.0.0.1:7421:80"
     env:
+      fpm: "true"
+      branch: "v2-develop"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
       VIRTUAL_HOST: "{{ (organizr.direct_domain|default(false,true)) | ternary(user.domain + ',' + 'www.' + user.domain,'organizr.' + user.domain) }}"
@@ -95,7 +97,7 @@
 
 - name: Download Plex Theme
   get_url:
-    url:  "https://raw.githubusercontent.com/Burry/organizr-v2-plex-theme/master/css/Plex.css"
+    url:  "https://raw.githubusercontent.com/gilbN/theme.park/master/CSS/themes/organizr/plex.css"
     dest: "/opt/organizr/www/Dashboard/css/themes/"
     owner: "{{ user.name }}"
     group: "{{ user.name }}"


### PR DESCRIPTION
This should be a drop-in replacement coming from organizrtools/organizr-v2. It has worked in all our tests.

Key-changes:

- The nginx config file for the healthcheck is moved to it's own file, under /config/nginx/site-confs/healthcheck.

- Moving the install directory from /config/www/Dashboard to /config/www/organizr, Nginx should also be updated with this change.

- One tag. While we could have set PHP to use the unix socket as default, we opted to using a environment varible. We also moved the branch selector to be a environment variable.

Old | New
-- | --
organizrtools/organizr-v2 | organizr/organizr
organizrtools/organizr-v2:dev | -e branch=dev organizr/organizr
organizrtools/organizr-v2:php-fpm | -e fpm=true organizr/organizr
organizrtools/organizr-v2:dev-php-fpm | -e branch=dev -e fpm=true organizr/organizr

