### PR TITLE
Rclone VFS: Update for full cache mode

### DIFF
--- a/roles/remote/defaults/main.yml
+++ b/roles/remote/defaults/main.yml
@@ -136,7 +136,6 @@ rclone_vfs_mount_start_command: |-
     --allow-non-empty \
     --rc \
     --rc-addr=localhost:5572 \
-    --no-checksum \
     --drive-skip-gdocs \
     --poll-interval=1m \
     --buffer-size=32M \

--- a/roles/remote/defaults/main.yml
+++ b/roles/remote/defaults/main.yml
@@ -136,7 +136,7 @@ rclone_vfs_mount_start_command: |-
     --allow-non-empty \
     --rc \
     --rc-addr=localhost:5572 \
-    --fast-list \
+    --no-checksum \
     --drive-skip-gdocs \
     --poll-interval=1m \
     --buffer-size=32M \
@@ -145,7 +145,7 @@ rclone_vfs_mount_start_command: |-
     --vfs-read-chunk-size-limit=2G \
     --vfs-cache-mode=full \
     --vfs-cache-max-age=168h \
-    --vfs-cache-max-size=150G \
+    --vfs-cache-max-size=50G \
     --dir-cache-time=168h \
     --timeout=10m \
     --drive-chunk-size=64M \

--- a/roles/remote/defaults/main.yml
+++ b/roles/remote/defaults/main.yml
@@ -138,10 +138,14 @@ rclone_vfs_mount_start_command: |-
     --rc-addr=localhost:5572 \
     --fast-list \
     --drive-skip-gdocs \
-    --vfs-read-chunk-size=64M \
-    --vfs-read-chunk-size-limit=2048M \
-    --buffer-size=64M \
     --poll-interval=1m \
+    --buffer-size=32M \
+    --vfs-read-ahead=128M \
+    --vfs-read-chunk-size=32M \
+    --vfs-read-chunk-size-limit=2G \
+    --vfs-cache-mode=full \
+    --vfs-cache-max-age=168h \
+    --vfs-cache-max-size=150G \
     --dir-cache-time=168h \
     --timeout=10m \
     --drive-chunk-size=64M \


### PR DESCRIPTION
Requires rclone >=1.53

Credit to darthShadow for example parameters