### PR TITLE
Sonarr: Docker image tag update

### DIFF
--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Create and start container
   docker_container:
     name: sonarr
-    image: "hotio/sonarr:unstable"
+    image: "hotio/sonarr:nightly"
     pull: yes
     published_ports:
       - "127.0.0.1:8989:8989"

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Create and start container
   docker_container:
     name: sonarr
-    image: "hotio/sonarr:phantom"
+    image: "hotio/sonarr:unstable"
     pull: yes
     published_ports:
       - "127.0.0.1:8989:8989"


### PR DESCRIPTION
`phantom` tag deprecated in favor of `nightly` tag for Sonarr v3