### PR TITLE
Sonarr: Docker image tag update

### DIFF
--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -51,7 +51,7 @@ sonarr_docker_container: "{{ sonarr_name }}"
 
 # Image
 sonarr_docker_image_pull: yes
-sonarr_docker_image_tag: "phantom"
+sonarr_docker_image_tag: "nightly"
 sonarr_docker_image: "hotio/sonarr:{{ sonarr_docker_image_tag }}"
 
 # Ports


### PR DESCRIPTION
`phantom` tag deprecated in favor of `nightly` tag for Sonarr v3