### PR TITLE
Radarr: Update Docker image tag

### DIFF
--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -51,7 +51,7 @@ radarr_docker_container: "{{ radarr_name }}"
 
 # Image
 radarr_docker_image_pull: yes
-radarr_docker_image_tag: "unstable"
+radarr_docker_image_tag: "testing"
 radarr_docker_image: "hotio/radarr:{{ radarr_docker_image_tag }}"
 
 # Ports


### PR DESCRIPTION
`unstable` tag deprecated in favor of `testing` tag.

This could also be changed to the `nightly` tag which would move to v3. I kept it as like-for-like for now.