### PR TITLE
Increase sysctl fs.inotify.max_user_watches

### DIFF
--- a/roles/system/tasks/subtasks/sysctl.yml
+++ b/roles/system/tasks/subtasks/sysctl.yml
@@ -70,7 +70,7 @@
     # Set default_qdisc to fq
     - { name: net.core.default_qdisc, value: fq }
     # Set max_user_watches for plex inotify
-    - { name: fs.inotify.max_user_watches, value: 131072 }
+    - { name: fs.inotify.max_user_watches, value: 524288 }
     # Set net.core.netdev_budget
     - { name: net.core.netdev_budget, value: 50000 }
 


### PR DESCRIPTION
Update fs.inotify.max_user_watches from default 131072 to 524288

This modification should help with plex scans / rescans where plex errors out and the DB locks up.