### PR TITLE
Update backup_excludes_list.txt

### DIFF
--- a/roles/backup/files/backup_excludes_list.txt
+++ b/roles/backup/files/backup_excludes_list.txt
@@ -19,11 +19,13 @@
 ./drive_strm/*.log*
 
 ./lidarr/logs/*
+./lidarr/MediaCover/*
 
 ./nvidia/*
 
 ./plex/Library/Application Support/Plex Media Server/Cache/PhotoTranscoder/*
 ./plex/Library/Application Support/Plex Media Server/Cache/Transcode/*
+./plex/Library/Application Support/Plex Media Server/Metadata/*
 
 ./plex_autoscan/plex_autoscan.log
 ./plex_autoscan/plex_autoscan.log.*
@@ -36,9 +38,13 @@
 ./tautulli/logs/*
 
 ./radarr/logs/*
+./radarr/MediaCover/*
 
 ./radarr4k/logs/*
+./radarr4k/MediaCover/*
 
 ./sonarr/logs/*
+./sonarr/MediaCover/*
 
 ./sonarr4k/logs/*
+./sonarr4k/MediaCover/*


### PR DESCRIPTION
Added MediaCover folder for arr, multiple Gb, even 10s of Gb of images that could be re downloaded
And the Metadata folder of plex that can also be redownloaded, reducing my backu personnally from 6 hours to 20 min