### PR TITLE
Remove music references in PAS config

### DIFF
--- a/roles/plex_autoscan/templates/config.json.j2
+++ b/roles/plex_autoscan/templates/config.json.j2
@@ -90,11 +90,6 @@
          "/tv/",
          "/mnt/unionfs/Media/TV/",
          "My Drive/Media/TV/"
-      ],
-      "/data/Music/":[
-         "/music/",
-         "/mnt/unionfs/Media/Music/",
-         "My Drive/Media/Music/"
       ]
    },
    "SERVER_PORT":3468,
@@ -106,9 +101,6 @@
       ],
       "1":[
          "/Movies/"
-      ],
-      "2":[
-         "/Music/"
       ]
    },
    "SERVER_USE_SQLITE":true,


### PR DESCRIPTION
Since plex-autoscan hasn't supported music for a long while, it makes sense to remove references to it from the base config.